### PR TITLE
Add targetted delay for breeze rate limits

### DIFF
--- a/Modules/Breeze/Breeze.psm1
+++ b/Modules/Breeze/Breeze.psm1
@@ -58,6 +58,10 @@ class Breeze {
         }
     }
 
+    [void] Pause() {
+        Start-Sleep -s 3.5
+    }    
+
     [Person] GetPersonById([int] $personId) {
         $personJSON = $this.GetPersonByIdAsJSON($personId)
         return [Person]::new($this.GetProfileFieldsAsJSON(), $personJSON)
@@ -65,6 +69,7 @@ class Breeze {
 
     [string] GetPersonByIdAsJSON([int] $personId) {
         $endpoint = $this.ENDPOINTS.PEOPLE + "/$personId"
+        Pause
         $response = Invoke-WebRequest -Uri $endpoint  -Method Get -Headers $this.Headers
         return $response.Content
     }
@@ -88,6 +93,7 @@ class Breeze {
 
     [string] GetPersonsFromTagIdAsJSON([int]$tagId) {
         $endpoint = $this.ENDPOINTS.PEOPLE + '?details=1&filter_json={"tag_contains":"y_' + [System.Web.HttpUtility]::UrlEncode($tagId) + '"}'
+        Pause
         $response = Invoke-WebRequest -Uri $endpoint  -Method Get -Headers $this.Headers
         return $response.Content
     }
@@ -110,7 +116,8 @@ class Breeze {
                 "&last=" + [System.Web.HttpUtility]::UrlEncode($person.GetLastName()) + `
                 "&middle=" + [System.Web.HttpUtility]::UrlEncode($person.GetMiddleName()) + `
                 "&nick=" + [System.Web.HttpUtility]::UrlEncode($person.GetNickName())
-            $breezePerson = Invoke-WebRequest -Uri $endpoint  -Method Post -Headers $this.Headers | ConvertFrom-Json
+                Pause
+                $breezePerson = Invoke-WebRequest -Uri $endpoint  -Method Post -Headers $this.Headers | ConvertFrom-Json
             if ($breezePerson -eq $null) { throw [System.ApplicationException]::new('Unable to create person: $person') }
             $person.id = $breezePerson.id
         }
@@ -122,6 +129,7 @@ class Breeze {
         # Update the additional Fields
         $personId = $person.id
         $endpoint = $this.ENDPOINTS.PEOPLE + "/update?person_id=$personId&fields_json=$fieldsJson"  
+        Pause
         $breezePerson = Invoke-WebRequest -Uri $endpoint  -Method Post -Headers $this.Headers | ConvertFrom-Json
         if ($breezePerson -eq $null) { throw [System.ApplicationException]::new('Unable to update person: $person') }
 
@@ -131,6 +139,7 @@ class Breeze {
             [Tag] $tag = $this.GetTagByName($tagName)
             [int] $tagId = $tag.id
             $endpoint = $this.ENDPOINTS.TAGS + "/assign?person_id=$personId&tag_id=$tagId"  
+            Pause
             $result = Invoke-WebRequest -Uri $endpoint  -Method Put -Headers $this.Headers | ConvertFrom-Json
         }
 
@@ -147,6 +156,7 @@ class Breeze {
     [void] DeletePerson([int] $personId) {
         if ($personId -eq 0) { throw [System.ArgumentException]::new('person id must be non-zero') }
         $endpoint = $this.ENDPOINTS.PEOPLE + "/delete?person_id=$personId"  
+        Pause
         Invoke-WebRequest -Uri $endpoint  -Method Delete -Headers $this.Headers | ConvertFrom-Json
     }
 
@@ -174,6 +184,7 @@ class Breeze {
 
     hidden [string] GetTagsAsJSON() {
         $endpoint = $this.ENDPOINTS.TAGS + '/list_tags'
+        Pause
         $response = Invoke-WebRequest -Uri $endpoint  -Method Get -Headers $this.Headers
         return $response.Content
     }
@@ -213,6 +224,7 @@ class Breeze {
 
         # Invalidate the taglist cache
         $this.TagList = $null
+        Pause
         $tagPSObject = Invoke-WebRequest -Uri $endpoint  -Method Get -Headers $this.Headers | ConvertFrom-Json
         $tag.id = $tagPSObject.id
         return $tag
@@ -228,6 +240,7 @@ class Breeze {
     [void] DeleteTag([int] $tagId) {
         if ($tagId -eq 0) { throw [System.ArgumentException]::new('tag id must be non-zero') }
         $endpoint = $this.ENDPOINTS.TAGS + "/delete_tag?tag_id=$tagId"  
+        Pause
         $result = Invoke-WebRequest -Uri $endpoint  -Method Delete -Headers $this.Headers | ConvertFrom-Json
     }
 
@@ -248,6 +261,7 @@ class Breeze {
         $endpoint = $this.ENDPOINTS.PROFILEFIELDS
 
         if ($this.ProfileFieldsJSON -eq $null) {
+            Pause
             $response = Invoke-WebRequest -Uri $endpoint  -Method Get -Headers $this.Headers
             $this.ProfileFieldsJSON = $response.Content
         }
@@ -265,6 +279,7 @@ class Breeze {
     [Person[]] GetPersonsByEmail([string] $email) {
         $emailFieldId = [Person]::GetProfileFieldId($this.GetProfileFields(), "Contact", "Email")
         $endpoint = $this.ENDPOINTS.PEOPLE + '?details=1&filter_json={"' + $emailFieldId + '":"' + $email + '"}'
+        Pause
         $response = Invoke-WebRequest -Uri $endpoint  -Method Get -Headers $this.Headers
         [Person[]] $persons = [Person]::ToPersons($this.GetProfileFieldsAsJSON(), $response.Content, $false)
         

--- a/Modules/Person/Person.psm1
+++ b/Modules/Person/Person.psm1
@@ -8,7 +8,7 @@
     Copyright (c) 2020 Chris D. Johnson All rights reserved.  
     Licensed under the Apache 2.0. See LICENSE file in the project root for full license information.  
 #>
-using assembly System.Web
+# using assembly System.Web
 using module ..\Logger\
 
 class Person {

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Sync Complete
 
 # Requirements and Details
 This utility has been tested with:
-- Windows 10 and 
+- Windows 10 and 11
 - Windows Server 2016
 - PowerShell 5.1.18362.628 or later
 - Tests require [Pester](https://github.com/pester/Pester)
@@ -196,13 +196,14 @@ To resolve:
 https://community.spiceworks.com/topic/2300404-can-t-create-office365-contact-object-conflict
 
 1. `Install-Module -Name AzureAD -AllowClobber -Scope AllUsers`
-2. 
+2. `Install-Module -Name MSOnline`
+3. 
 ```
 Get-MsolContact -All | ? {$_.EmailAddress -eq "Email@gmail.com"} |fl Objectid
 ObjectId : cceb6517-000e-4a67-8b0b-67840800c96b
 ```
-3. `Get-AzureADObjectByObjectId -objectid cceb6517-000e-4a67-8b0b-67840800c96b`
-4. `Remove-AzureADContact -objectid cceb6517-000e-4a67-8b0b-67840800c96b`
+4. `Get-AzureADObjectByObjectId -objectid 432764c6-4e51-477d-847f-401a01ac3527`
+5. `Remove-AzureADContact -objectid 432764c6-4e51-477d-847f-401a01ac3527`
 
 # Support
 This software is Apache 2.0 license and the source is therefore freely available.
@@ -211,3 +212,4 @@ To ask questions and open issues and download the latest release, see:
 https://github.com/gracecode-org/breeze-outlook-sync/issues
 
 
+  Get-MsolContact -All | ? {$_.EmailAddress -eq "kellyg@smmpa.org"} |fl Objectid

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ https://community.spiceworks.com/topic/2300404-can-t-create-office365-contact-ob
 Get-MsolContact -All | ? {$_.EmailAddress -eq "Email@gmail.com"} |fl Objectid
 ObjectId : cceb6517-000e-4a67-8b0b-67840800c96b
 ```
-4. `Get-AzureADObjectByObjectId -objectid 432764c6-4e51-477d-847f-401a01ac3527`
-5. `Remove-AzureADContact -objectid 432764c6-4e51-477d-847f-401a01ac3527`
+4. `Get-AzureADObjectByObjectId -objectid cceb6517-000e-4a67-8b0b-67840800c96b`
+5. `Remove-AzureADContact -objectid cceb6517-000e-4a67-8b0b-67840800c96b`
 
 # Support
 This software is Apache 2.0 license and the source is therefore freely available.

--- a/tests/Breeze.Tests.ps1
+++ b/tests/Breeze.Tests.ps1
@@ -56,6 +56,8 @@ function GetTestPersons([Breeze] $breeze, [boolean] $setIds) {
 
 Describe "Person" {
     $TEST_PROFILE_FIELDS=[IO.File]::ReadAllText([MockBreeze]::PROFILE_FIELDS_FILE)
+    
+    $TEST_PROFILE_FIELDS | Should -Not -BeNullOrEmpty
 
     It "GetProfileFieldId" {
         $p1 = [Person]::new($TEST_PROFILE_FIELDS, 0, "Test", "Nick", "Mid", "User", `
@@ -320,6 +322,7 @@ Describe "Person" {
         "100 Main St", "Rochester", "MN", "55901", @("TEST1", "TEST2"))
         $p1.GetFirstPrimaryEmail() | Should -Be "testuser@yopmail.com"
     }
+}
 
 Describe "BreezeCache" {
     $TEST_PROFILE_FIELDS=[IO.File]::ReadAllText([MockBreeze]::PROFILE_FIELDS_FILE)


### PR DESCRIPTION
Added a more precise 3.5s pause for Breeze HTTP calls to avoid Rate Limiting errors.
Added a configuration value to prevent large Tags from being synchronized
